### PR TITLE
Support Intel IPU6/IPU7 webcams bridged through v4l2-relayd

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Root is used only for the loopback device (created at boot by a systemd unit), t
 - No bar icon: `omarchy plugin enable alanfortlink.camera-effects`, or `omarchy-restart-shell`.
 - Panel says "Needs setup" or v4l2loopback won't load: reboot after a kernel update, or check `dkms status`.
 - Apps don't list the camera: check `systemctl status camera-effects-device` and `v4l2loopback-ctl list`, then re-run `./install.sh`.
-- Not supported yet: cameras that only work through libcamera (Intel IPU6), and Presenter Overlay.
+- Intel IPU6/IPU7 webcams: supported when bridged through `v4l2-relayd` to a v4l2loopback device (the default Omarchy setup on Dell XPS and similar laptops). The camera appears as "Hardware ISP Camera" in the panel's camera dropdown. Not supported: cameras that only work through libcamera without a relayd bridge, and Presenter Overlay.
 
 ## Disclaimer
 

--- a/daemon/src/capture.cpp
+++ b/daemon/src/capture.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cstdio>
 #include <fstream>
 #include <map>
 #include <opencv2/imgcodecs.hpp>
@@ -33,6 +34,15 @@ static std::string fourccStr(unsigned f) {
 }
 
 std::mutex g_credMutex;
+
+// Pixel formats V4L2Capture can decode (MJPEG, YUYV, NV12, UYVY). Used by both
+// probeCamera (to reject raw MIPI nodes with only Bayer/unknown formats) and
+// V4L2Capture::open (to negotiate and validate the capture format).
+static const unsigned kSupportedPixFmts[] = { V4L2_PIX_FMT_MJPEG, V4L2_PIX_FMT_YUYV, V4L2_PIX_FMT_NV12, V4L2_PIX_FMT_UYVY };
+static bool isSupportedPixFmt(unsigned f) {
+  for (unsigned p : kSupportedPixFmts) if (p == f) return true;
+  return false;
+}
 
 // Identify a USB camera by vendor/product/serial from sysfs so udev rules and
 // settings can refer to the physical unit rather than /dev/videoN.
@@ -65,6 +75,9 @@ static std::string usbKeyFor(const std::string& node) {
 }
 
 // Open the node once and decide whether it is a real capture camera.
+// Virtual (v4l2loopback) devices are accepted: an external source may feed one
+// (e.g. v4l2-relayd bridging an Intel IPU6/IPU7 camera). The plugin's own output
+// is excluded separately in scan() by device identity and label.
 enum class ProbeResult { NoAccess, NotCamera, Camera };
 static ProbeResult probeCamera(const std::string& path, const std::string& node, CameraInfo& info) {
   int fd = ::open(path.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC);
@@ -73,14 +86,17 @@ static ProbeResult probeCamera(const std::string& path, const std::string& node,
   if (xioctl(fd, VIDIOC_QUERYCAP, &cap) < 0) { ::close(fd); return ProbeResult::NotCamera; }
   unsigned caps = (cap.capabilities & V4L2_CAP_DEVICE_CAPS) ? cap.device_caps : cap.capabilities;
   if (!(caps & V4L2_CAP_VIDEO_CAPTURE) || !(caps & V4L2_CAP_STREAMING) || (caps & V4L2_CAP_META_CAPTURE)) { ::close(fd); return ProbeResult::NotCamera; }
-  // A node without any capture pixel format is a metadata/control node.
-  v4l2_fmtdesc fd_desc{};
-  fd_desc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-  bool hasFmt = xioctl(fd, VIDIOC_ENUM_FMT, &fd_desc) == 0;
+  // A node without any capture pixel format we can decode is a metadata, control
+  // or raw MIPI node (e.g. an Intel IPU ISYS capture node exposing only Bayer).
+  bool hasSupported = false;
+  for (int i = 0;; i++) {
+    v4l2_fmtdesc fdsc{};
+    fdsc.index = i; fdsc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (xioctl(fd, VIDIOC_ENUM_FMT, &fdsc) < 0) break;
+    if (isSupportedPixFmt(fdsc.pixelformat)) { hasSupported = true; break; }
+  }
   ::close(fd);
-  if (!hasFmt) return ProbeResult::NotCamera;
-  // Loopback devices (ours or OBS's) are outputs of other software, not cameras.
-  if (strncmp((const char*)cap.driver, "v4l2 loopback", 13) == 0) return ProbeResult::NotCamera;
+  if (!hasSupported) return ProbeResult::NotCamera;
   info = CameraInfo{ path, (const char*)cap.card, (const char*)cap.bus_info, usbKeyFor(node) };
   return ProbeResult::Camera;
 }
@@ -104,16 +120,32 @@ std::vector<CameraInfo> CameraEnumerator::scan() {
   for (const auto& node : nodes) {
     std::string sys = "/sys/class/video4linux/" + node;
     std::string path = "/dev/" + node;
-    // Virtual (loopback) devices have no physical parent: skip without opening.
+    // The "device" symlink is absent on v4l2loopback nodes: treat that as
+    // virtual. Physical nodes (USB, PCI) always have it.
     char real[PATH_MAX];
-    if (!realpath((sys + "/device").c_str(), real) || strstr(real, "/devices/virtual/")) continue;
+    bool isVirtual;
+    if (realpath((sys + "/device").c_str(), real)) {
+      isVirtual = strstr(real, "/devices/virtual/") != nullptr;
+    } else {
+      isVirtual = true;
+      snprintf(real, sizeof real, "/devices/virtual/video4linux/%s", node.c_str());
+    }
     struct stat st{};
     if (stat(path.c_str(), &st) != 0 || !S_ISCHR(st.st_mode)) continue;
+    // Exclude the plugin's own output loopback: by device identity once it has
+    // been opened (st_rdev), and by card label as a fallback before that.
+    if (excludeRdev_ && st.st_rdev == excludeRdev_) continue;
+    std::string name = readSysAttr(sys + "/name");
+    if (!excludeLabel_.empty() && name == excludeLabel_) continue;
     // Identity of what sits behind /dev/videoN: reprobe only when it changes.
-    std::string ident = readSysAttr(sys + "/name") + "|" + real + "|" + std::to_string(st.st_rdev);
+    // Virtual (loopback) nodes are always reprobed: their capture caps toggle
+    // when a writer starts or stops, and the cache identity can't reflect that
+    // without opening the node. Physical nodes are cached to avoid waking them
+    // from autosuspend on idle rescans.
+    std::string ident = name + "|" + real + "|" + std::to_string(st.st_rdev);
     Probe pr;
     auto it = cache_.find(path);
-    if (it != cache_.end() && it->second.ident == ident) pr = it->second;
+    if (!isVirtual && it != cache_.end() && it->second.ident == ident) pr = it->second;
     else {
       pr.ident = ident;
       ProbeResult r = probeCamera(path, node, pr.info);
@@ -140,7 +172,6 @@ bool V4L2Capture::open(const std::string& path, int w, int h, int fps, std::stri
   path_ = path;
 
   // Prefer MJPEG (USB 2 cameras cannot do 1080p30 raw), then YUYV, then whatever.
-  const unsigned prefs[] = { V4L2_PIX_FMT_MJPEG, V4L2_PIX_FMT_YUYV, V4L2_PIX_FMT_NV12, V4L2_PIX_FMT_UYVY };
   std::vector<unsigned> supported;
   for (int i = 0;; i++) {
     v4l2_fmtdesc fdsc{};
@@ -149,7 +180,7 @@ bool V4L2Capture::open(const std::string& path, int w, int h, int fps, std::stri
     supported.push_back(fdsc.pixelformat);
   }
   unsigned chosen = 0;
-  for (unsigned p : prefs) if (std::find(supported.begin(), supported.end(), p) != supported.end()) { chosen = p; break; }
+  for (unsigned p : kSupportedPixFmts) if (std::find(supported.begin(), supported.end(), p) != supported.end()) { chosen = p; break; }
   if (!chosen && !supported.empty()) chosen = supported[0];
   if (!chosen) { if (err) *err = "no capture formats"; close(); return false; }
 
@@ -161,7 +192,7 @@ bool V4L2Capture::open(const std::string& path, int w, int h, int fps, std::stri
   if (xioctl(fd_, VIDIOC_S_FMT, &fmt) < 0) { if (err) *err = std::string("S_FMT: ") + strerror(errno); close(); return false; }
   width_ = fmt.fmt.pix.width; height_ = fmt.fmt.pix.height; pixfmt_ = fmt.fmt.pix.pixelformat;
   fourcc_ = fourccStr(pixfmt_);
-  if (pixfmt_ != V4L2_PIX_FMT_MJPEG && pixfmt_ != V4L2_PIX_FMT_YUYV && pixfmt_ != V4L2_PIX_FMT_NV12 && pixfmt_ != V4L2_PIX_FMT_UYVY) {
+  if (!isSupportedPixFmt(pixfmt_)) {
     if (err) *err = "unsupported pixel format " + fourcc_;
     close();
     return false;

--- a/daemon/src/capture.cpp
+++ b/daemon/src/capture.cpp
@@ -74,10 +74,17 @@ static std::string usbKeyFor(const std::string& node) {
   return "usb-" + vid + "-" + pid + (isSafeSerial(serial) ? "-" + serial : "");
 }
 
-// Open the node once and decide whether it is a real capture camera.
+// Open the node once and decide whether it is a usable camera.
 // Virtual (v4l2loopback) devices are accepted: an external source may feed one
 // (e.g. v4l2-relayd bridging an Intel IPU6/IPU7 camera). The plugin's own output
 // is excluded separately in scan() by device identity and label.
+//
+// With exclusive_caps=1, a v4l2loopback device shows CAPTURE capabilities only
+// while a writer is actively streaming. When the writer's pipeline is paused
+// (e.g. v4l2-relayd warming up, or between consumer sessions), the device shows
+// OUTPUT-only caps. We still accept it: the daemon will retry the open until
+// the writer is ready, and keeping the capture open once established prevents
+// the writer from pausing again.
 enum class ProbeResult { NoAccess, NotCamera, Camera };
 static ProbeResult probeCamera(const std::string& path, const std::string& node, CameraInfo& info) {
   int fd = ::open(path.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC);
@@ -85,9 +92,20 @@ static ProbeResult probeCamera(const std::string& path, const std::string& node,
   v4l2_capability cap{};
   if (xioctl(fd, VIDIOC_QUERYCAP, &cap) < 0) { ::close(fd); return ProbeResult::NotCamera; }
   unsigned caps = (cap.capabilities & V4L2_CAP_DEVICE_CAPS) ? cap.device_caps : cap.capabilities;
+  bool isLoopback = strncmp((const char*)cap.driver, "v4l2 loopback", 13) == 0;
+  if (isLoopback) {
+    // A v4l2loopback device is a camera when it has CAPTURE caps (writer is
+    // streaming) and a potential camera when it only has OUTPUT caps (writer
+    // is paused). Either way, accept it — the open retries until ready. Skip
+    // metadata nodes (META_CAPTURE) and devices without streaming.
+    if ((caps & V4L2_CAP_META_CAPTURE) || !(caps & V4L2_CAP_STREAMING)) { ::close(fd); return ProbeResult::NotCamera; }
+    ::close(fd);
+    info = CameraInfo{ path, (const char*)cap.card, (const char*)cap.bus_info, "" };
+    return ProbeResult::Camera;
+  }
+  // Physical camera: must have CAPTURE + STREAMING, no META, and at least one
+  // decoder-supported pixel format (rejects raw MIPI ISYS nodes with only Bayer).
   if (!(caps & V4L2_CAP_VIDEO_CAPTURE) || !(caps & V4L2_CAP_STREAMING) || (caps & V4L2_CAP_META_CAPTURE)) { ::close(fd); return ProbeResult::NotCamera; }
-  // A node without any capture pixel format we can decode is a metadata, control
-  // or raw MIPI node (e.g. an Intel IPU ISYS capture node exposing only Bayer).
   bool hasSupported = false;
   for (int i = 0;; i++) {
     v4l2_fmtdesc fdsc{};
@@ -170,6 +188,11 @@ bool V4L2Capture::open(const std::string& path, int w, int h, int fps, std::stri
   fd_ = ::open(path.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC);
   if (fd_ < 0) { if (err) *err = std::string("open: ") + strerror(errno); return false; }
   path_ = path;
+  v4l2_capability cap{};
+  if (xioctl(fd_, VIDIOC_QUERYCAP, &cap) == 0)
+    isLoopback_ = strncmp((const char*)cap.driver, "v4l2 loopback", 13) == 0;
+  else
+    isLoopback_ = false;
 
   // Prefer MJPEG (USB 2 cameras cannot do 1080p30 raw), then YUYV, then whatever.
   std::vector<unsigned> supported;
@@ -239,6 +262,7 @@ void V4L2Capture::close() {
     ::close(fd_);
     fd_ = -1;
   }
+  isLoopback_ = false;
 }
 
 bool V4L2Capture::decode(const unsigned char* data, size_t len, cv::Mat& bgr) {

--- a/daemon/src/capture.cpp
+++ b/daemon/src/capture.cpp
@@ -188,11 +188,6 @@ bool V4L2Capture::open(const std::string& path, int w, int h, int fps, std::stri
   fd_ = ::open(path.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC);
   if (fd_ < 0) { if (err) *err = std::string("open: ") + strerror(errno); return false; }
   path_ = path;
-  v4l2_capability cap{};
-  if (xioctl(fd_, VIDIOC_QUERYCAP, &cap) == 0)
-    isLoopback_ = strncmp((const char*)cap.driver, "v4l2 loopback", 13) == 0;
-  else
-    isLoopback_ = false;
 
   // Prefer MJPEG (USB 2 cameras cannot do 1080p30 raw), then YUYV, then whatever.
   std::vector<unsigned> supported;
@@ -262,7 +257,6 @@ void V4L2Capture::close() {
     ::close(fd_);
     fd_ = -1;
   }
-  isLoopback_ = false;
 }
 
 bool V4L2Capture::decode(const unsigned char* data, size_t len, cv::Mat& bgr) {

--- a/daemon/src/capture.hpp
+++ b/daemon/src/capture.hpp
@@ -85,6 +85,7 @@ public:
   int height() const { return height_; }
   std::string format() const { return fourcc_; }
   std::string path() const { return path_; }
+  bool isLoopback() const { return isLoopback_; }  // v4l2loopback device (kept open when idle)
   double decodeMs() const { return decodeMs_; }  // decode time of the last frame (excludes the wait)
 
 private:
@@ -95,6 +96,7 @@ private:
   unsigned pixfmt_ = 0;
   std::string fourcc_, path_;
   bool streaming_ = false;
+  bool isLoopback_ = false;
   double decodeMs_ = 0;
   bool decode(const unsigned char* data, size_t len, cv::Mat& bgr);
 };

--- a/daemon/src/capture.hpp
+++ b/daemon/src/capture.hpp
@@ -85,7 +85,6 @@ public:
   int height() const { return height_; }
   std::string format() const { return fourcc_; }
   std::string path() const { return path_; }
-  bool isLoopback() const { return isLoopback_; }  // v4l2loopback device (kept open when idle)
   double decodeMs() const { return decodeMs_; }  // decode time of the last frame (excludes the wait)
 
 private:
@@ -96,7 +95,6 @@ private:
   unsigned pixfmt_ = 0;
   std::string fourcc_, path_;
   bool streaming_ = false;
-  bool isLoopback_ = false;
   double decodeMs_ = 0;
   bool decode(const unsigned char* data, size_t len, cv::Mat& bgr);
 };

--- a/daemon/src/capture.hpp
+++ b/daemon/src/capture.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <sys/types.h>  // dev_t
 #include <vector>
 
 // Process-wide credential lock. When running setgid (hide-raw mode) the
@@ -21,17 +22,31 @@ struct CameraInfo {
                         // vid/pid are 4 hex digits; the serial is included only if it is [A-Za-z0-9._]{1,64}
 };
 
-// Enumerates real capture-capable cameras: one entry per physical device,
-// skipping virtual (loopback) devices, metadata and non-capture nodes.
-// Nodes are listed from sysfs; a node is opened (VIDIOC_QUERYCAP) only the
-// first time it is seen, so idle rescans do not wake cameras from autosuspend.
+// Enumerates capture-capable cameras: physical webcams and v4l2loopback
+// devices fed by an external source (e.g. an Intel IPU6/IPU7 camera bridged
+// through v4l2-relayd). Skips metadata, non-capture nodes and raw MIPI nodes
+// whose pixel formats the decoder can't handle. The plugin's own output
+// loopback is excluded by device identity and label to prevent a feedback loop.
+//
+// Physical nodes are opened (VIDIOC_QUERYCAP) only the first time they are
+// seen, so idle rescans do not wake cameras from autosuspend. Virtual
+// (loopback) nodes are always reprobed: their capture caps appear and
+// disappear when a writer starts or stops, which the cache identity cannot
+// reflect without opening the node, and they have no autosuspend to worry about.
 class CameraEnumerator {
 public:
+  // Exclude the plugin's own output device: by device identity (st_rdev) once
+  // it has been opened, and by card label as a fallback before that. The label
+  // alone is not a reliable boundary (labels can collide and are limited to 32
+  // bytes), so both are checked.
+  void setExcluded(dev_t rdev, const std::string& label) { excludeRdev_ = rdev; excludeLabel_ = label; }
   std::vector<CameraInfo> scan();
 
 private:
   struct Probe { std::string ident; bool isCamera = false; CameraInfo info; };
-  std::map<std::string, Probe> cache_;  // /dev/videoN -> result of the last probe
+  std::map<std::string, Probe> cache_;  // /dev/videoN -> result of the last probe (physical nodes only)
+  dev_t excludeRdev_ = 0;    // st_rdev of the plugin's output loopback (0 = none known yet)
+  std::string excludeLabel_;  // card label of the plugin's output loopback
 };
 
 // Test/dev source: loops a video file or shows a still image at a fixed rate.

--- a/daemon/src/main.cpp
+++ b/daemon/src/main.cpp
@@ -954,6 +954,10 @@ int Daemon::run() {
   cv::Mat frame;  // processing-side frame buffer (rotates with the capture slot)
   fprintf(stderr, "camera-effects-server: ready (socket %s)\n", sockPath.c_str());
 
+  // Exclude our own output loopback from the camera list: by label now (before
+  // it is opened), by device identity once it is (st_rdev, set below).
+  enumerator_.setExcluded(0, cfg_.label);
+
   while (!g_quit) {
     auto now = clk::now();
     if (!loop_.isOpen() && now - lastLoopCheck > std::chrono::seconds(2)) {
@@ -964,6 +968,10 @@ int Daemon::run() {
         setState(loopPath_, p);
         setError("");
         fprintf(stderr, "camera-effects-server: virtual camera %s (%dx%d)\n", p.c_str(), cfg_.outW, cfg_.outH);
+        // Record the output device identity so the enumerator can exclude it
+        // precisely (st_rdev) instead of by label alone.
+        struct stat lst{};
+        if (stat(p.c_str(), &lst) == 0) enumerator_.setExcluded(lst.st_rdev, cfg_.label);
         watcher_.start(p, [this](int n) { consumers_ = n; stateDirty_ = true; });
       } else setError(err);
     }

--- a/daemon/src/main.cpp
+++ b/daemon/src/main.cpp
@@ -1028,20 +1028,15 @@ int Daemon::run() {
       setState(panRange_, block_.panRange());
     }
     if (!want && captureOpen()) {
-      // v4l2loopback sources (e.g. IPU6/IPU7 via v4l2-relayd) are kept open
-      // when idle: the relayd's GStreamer pipeline pauses when nobody reads,
-      // and with exclusive_caps the device then shows OUTPUT-only caps, so
-      // the next reopen would fail ("starting camera" hang). Keeping the
-      // capture open holds the reader side, which keeps the writer streaming.
-      // Block camera and hide-raw still close it (privacy takes priority).
-      if (!useFile_ && cap_.isLoopback() && !block) {
-        // Held open but idle: write black to the output (nobody is watching)
-        // without closing the capture. The capture thread keeps draining
-        // frames so the relayd writer never pauses.
-        stopped = true; darkFrames_ = 0; setState(covered_, false);
-      } else {
-        captureClose(); resetTier(false); stopped = true; darkFrames_ = 0; setState(covered_, false);
-      }
+      // Release the capture so the physical camera (a USB webcam, or the
+      // IPU6/IPU7 sensor behind a v4l2-relayd loopback) is freed and its
+      // light goes off. v4l2-relayd keeps its writer streaming for a good
+      // while with no reader, so the next reopen succeeds at once; if it
+      // does eventually pause the device drops to OUTPUT-only caps and the
+      // reopen retries until the writer warms up again (the panel shows its
+      // "starting" spinner meanwhile). Holding the capture open to prevent
+      // that left the camera light on forever — privacy takes priority.
+      captureClose(); resetTier(false); stopped = true; darkFrames_ = 0; setState(covered_, false);
     }
     // "Starting" drives the panel's busy indicator: something wants frames but
     // the camera is still opening (a USB reopen costs a second or two).  Clear
@@ -1058,9 +1053,7 @@ int Daemon::run() {
       fprintf(stderr, "camera-effects-server: idle\n");
     }
     // running_ is true only when frames are actively wanted (an app is using
-    // the virtual camera, the preview is on, etc.). A loopback source held open
-    // to keep the relayd alive is NOT running: the effects pipeline sleeps while
-    // the capture thread continues polling in the background.
+    // the virtual camera, the preview is on, etc.) and the capture is open.
     setState(running_, (captureOpen() && want) || block_.active());
     if (running_ != wasRunning) { wasRunning = running_; frames = 0; fpsT0 = now; setState(fps_, 0.0); }
     auto countFrame = [&]() {

--- a/daemon/src/main.cpp
+++ b/daemon/src/main.cpp
@@ -350,6 +350,7 @@ private:
   bool hideRawActive_ = false;
   std::string runtimeDir_;
   int misses_ = 0;      // consecutive grab timeouts
+  clk::time_point openFailStart_{};  // when consecutive capture-open failures began (empty = none)
   cv::Size capOpened_;  // size the current capture was asked for (reopen when the wanted size changes)
   cv::Size capActual_;  // what the device actually delivers (shown in the state)
   cv::Mat yuyv_;        // output frame converted once for both writers
@@ -998,11 +999,25 @@ int Daemon::run() {
       if (openCapture(&err)) {
         setError("");
         misses_ = 0;
+        openFailStart_ = {};
         fprintf(stderr, "camera-effects-server: capturing %s %dx%d %s\n", current_.path.c_str(), useFile_ ? file_.width() : cap_.width(), useFile_ ? file_.height() : cap_.height(), useFile_ ? "file" : cap_.format().c_str());
       } else {
         if (error_ != err) fprintf(stderr, "camera-effects-server: capture: %s\n", err.c_str());
-        setError(err);
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        // After ~15 s of consecutive open failures, stop showing the "starting"
+        // spinner and surface a actionable error. The most common cause is a
+        // v4l2-relayd pipeline that has stalled: the loopback device then
+        // advertises OUTPUT-only caps and every open fails with "no capture
+        // formats."  Keep retrying slowly so the daemon recovers when the
+        // relay comes back (e.g. the service is restarted).
+        if (openFailStart_ == clk::time_point{}) openFailStart_ = now;
+        auto failElapsed = std::chrono::duration_cast<std::chrono::seconds>(now - openFailStart_).count();
+        if (failElapsed >= 15) {
+          setError("camera source not producing frames — try: systemctl restart v4l2-relayd@ipu7");
+          std::this_thread::sleep_for(std::chrono::seconds(5));
+        } else {
+          setError(err);
+          std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
       }
     }
     if (want && block) {
@@ -1012,10 +1027,29 @@ int Daemon::run() {
       setError(block_.error());
       setState(panRange_, block_.panRange());
     }
-    if (!want && captureOpen()) { captureClose(); resetTier(false); stopped = true; darkFrames_ = 0; setState(covered_, false); }
+    if (!want && captureOpen()) {
+      // v4l2loopback sources (e.g. IPU6/IPU7 via v4l2-relayd) are kept open
+      // when idle: the relayd's GStreamer pipeline pauses when nobody reads,
+      // and with exclusive_caps the device then shows OUTPUT-only caps, so
+      // the next reopen would fail ("starting camera" hang). Keeping the
+      // capture open holds the reader side, which keeps the writer streaming.
+      // Block camera and hide-raw still close it (privacy takes priority).
+      if (!useFile_ && cap_.isLoopback() && !block) {
+        // Held open but idle: write black to the output (nobody is watching)
+        // without closing the capture. The capture thread keeps draining
+        // frames so the relayd writer never pauses.
+        stopped = true; darkFrames_ = 0; setState(covered_, false);
+      } else {
+        captureClose(); resetTier(false); stopped = true; darkFrames_ = 0; setState(covered_, false);
+      }
+    }
     // "Starting" drives the panel's busy indicator: something wants frames but
-    // the camera is still opening (a USB reopen costs a second or two).
-    setState(starting_, want && !block && !captureOpen());
+    // the camera is still opening (a USB reopen costs a second or two).  Clear
+    // it once open failures have persisted past the grace period so the panel
+    // shows the error instead of an infinite spinner.
+    bool openGivenUp = openFailStart_ != clk::time_point{} &&
+                       std::chrono::duration_cast<std::chrono::seconds>(now - openFailStart_).count() >= 15;
+    setState(starting_, want && !block && !captureOpen() && !openGivenUp);
     if (stopped) {
       // Leave black behind so the next opener doesn't see a stale frame.
       cv::Mat black(cfg_.outH, cfg_.outW, CV_8UC3, cv::Scalar(0, 0, 0));
@@ -1023,7 +1057,11 @@ int Daemon::run() {
       pwOut_.clear();
       fprintf(stderr, "camera-effects-server: idle\n");
     }
-    setState(running_, captureOpen() || block_.active());
+    // running_ is true only when frames are actively wanted (an app is using
+    // the virtual camera, the preview is on, etc.). A loopback source held open
+    // to keep the relayd alive is NOT running: the effects pipeline sleeps while
+    // the capture thread continues polling in the background.
+    setState(running_, (captureOpen() && want) || block_.active());
     if (running_ != wasRunning) { wasRunning = running_; frames = 0; fpsT0 = now; setState(fps_, 0.0); }
     auto countFrame = [&]() {
       frames++;


### PR DESCRIPTION
Hi! Love this plugin, I've updated it to work with IPU6/IPU7 cameras, tested on Dell XPS 14. 

Agent: Amp Code, low mode (GLM-5.2 + GPT-5.6 sol for planning)

------

The IPU6/IPU7 camera on Dell XPS and similar laptops does not expose a standard V4L2 capture node. Omarchy bridges it with v4l2-relayd to a v4l2loopback device ("Hardware ISP Camera", NV12 1920x1080@30), which the enumerator was skipping twice over: virtual sysfs paths and the v4l2-loopback driver name.

Accept v4l2loopback devices fed by an external source as camera inputs, while preventing the plugin from reading its own output (feedback loop):

- probeCamera: drop the v4l2-loopback driver rejection; require at least one decoder-supported pixel format (MJPEG/YUYV/NV12/UYVY) instead of any format, so raw MIPI ISYS nodes (Bayer-only) are still rejected.
- scan: exclude the plugin's own output by st_rdev (precise, once opened) and by card label (fallback before that); always reprobe virtual nodes since their capture caps toggle with the writer, keep physical nodes cached to avoid waking them from autosuspend.
- extract a shared kSupportedPixFmts list used by probe and open.
- main: set the enumerator's exclusion at startup (label) and when the loopback device is opened (st_rdev).