### PR TITLE
Detect dependencies satisfied by a provider

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,9 +35,13 @@ if [[ $MODE == --uninstall ]]; then
 fi
 
 # Build/runtime dependencies (all in the Omarchy/Arch repos).
+# pacman -T, not -Q: -Q matches installed package *names* only, so a dependency
+# already satisfied by a package that provides it under another name looks missing.
+# onnxruntime-rocm provides onnxruntime and conflicts with it, so the install below
+# would offer to replace a working accelerated build with the plain one.
 missing=()
 for p in gcc make pkgconf opencv onnxruntime pipewire qt6-multimedia v4l2loopback-dkms dkms; do
-  pacman -Q "$p" >/dev/null 2>&1 || missing+=("$p")
+  pacman -T "$p" >/dev/null 2>&1 || missing+=("$p")
 done
 # The dkms module needs the running kernel's headers; pick the package for this kernel flavour.
 krel=$(uname -r)


### PR DESCRIPTION
`install.sh` tests each build dependency with `pacman -Q`, which matches installed package **names** only. A dependency that is already satisfied by a package providing it under a different name therefore reads as missing, and the install step below tries to install it.

That is a problem for `onnxruntime` specifically, because `onnxruntime-rocm` (and `onnxruntime-opt`, `onnxruntime-cuda`, and similar builds) both **provides** `onnxruntime` and **conflicts** with it:

```
$ pacman -Qi onnxruntime-rocm | grep -E 'Provides|Conflicts'
Provides        : onnxruntime=1.28.0
Conflicts With  : onnxruntime

$ pacman -Q onnxruntime          # what install.sh asks
error: package 'onnxruntime' was not found

$ pacman -T onnxruntime          # provider-aware; already satisfied
$ echo $?
0
```

So on a machine with an accelerated onnxruntime build, `./install.sh` adds `onnxruntime` to `missing` and runs `pacman -S --needed --noconfirm onnxruntime`, which resolves the conflict by removing the user's ROCm/CUDA build. On my box that package is also an optional dependency of Firefox, so the blast radius reaches beyond this plugin. Because the call passes `--noconfirm` there is no prompt to decline — depending on how pacman resolves it you either lose the accelerated build or the install fails outright on an unresolvable conflict.

`pacman -T` (deptest) is the provider-aware equivalent, resolves `provides`, and needs no root, so it is a drop-in for the check. The rest of the loop is unchanged: a genuinely missing package still lands in `missing` and still gets installed.

Verified on Omarchy 4 / Arch, kernel 7.0.9-arch2-1, with `onnxruntime-rocm 1.28.0-1` installed: before the change the dependency step wanted to replace it, after the change the daemon builds and links against the existing ROCm build and `onnxruntime-rocm` is left alone. The virtual camera, panel, Center Stage, Portrait, Studio Light, backgrounds, filters and face effects all work.

Thanks for the plugin — the privileged half is unusually careful about ownership and udev, it was a pleasure to read.
