### PR TITLE
Save snapshots somewhere writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Thanks to [@prettyletto](https://github.com/prettyletto) for sending me this vid
 - **Filters** (mono, sepia, warm, cool, vivid, soft, sharpen, vintage) and **Effects** (sunglasses, top hat, crown, cat, halo and more).
 - **Reactions** such as hearts, confetti, balloons and fireworks, played with a click or by holding a hand gesture at the camera.
 - Manual framing: zoom, drag-to-pan, fit mode, rotate and mirror.
-- **Snapshots** with a 3·2·1 countdown, saved to `~/Pictures/Camera Effects/` and copied to the clipboard.
+- **Snapshots** with a 3·2·1 countdown, saved to `Camera Effects/` in your pictures directory and copied to the clipboard.
 - **Privacy**: block the camera with a card, image or video, or hide the raw webcam so apps only see Camera Effects.
 - Several webcams? Pick the source in the panel and keep shared or per-camera settings.
 - Everything runs on the CPU, locally. Nothing leaves your machine.

--- a/daemon/src/main.cpp
+++ b/daemon/src/main.cpp
@@ -9,7 +9,7 @@
 // small JPEG the daemon writes to the runtime dir while a preview is wanted:
 // the loopback lets a single reader negotiate the format, so a second reader
 // (the panel) would see nothing while an app streams. A snapshot request
-// saves the next output frame as a PNG under ~/Pictures/Camera Effects.
+// saves the next output frame as a PNG under the pictures directory.
 #include <fcntl.h>
 #include <linux/videodev2.h>
 #include <pwd.h>
@@ -63,6 +63,39 @@ std::string homeDir() {
 std::string xdgConfig() { const char* c = getenv("XDG_CONFIG_HOME"); return c && *c ? c : homeDir() + "/.config"; }
 std::string xdgData() { const char* c = getenv("XDG_DATA_HOME"); return c && *c ? c : homeDir() + "/.local/share"; }
 std::string xdgRuntime() { const char* c = getenv("XDG_RUNTIME_DIR"); return c && *c ? c : "/tmp"; }
+
+// The pictures directory. XDG_PICTURES_DIR is a user-dirs setting rather than an
+// exported variable, so read user-dirs.dirs when it is not in the environment;
+// a "$HOME/..." value there is expanded.
+std::string xdgPictures() {
+  const char* p = getenv("XDG_PICTURES_DIR");
+  if (p && *p) return p;
+  const std::string key = "XDG_PICTURES_DIR=";
+  std::ifstream f(xdgConfig() + "/user-dirs.dirs");
+  std::string line;
+  while (std::getline(f, line)) {
+    size_t k = line.find(key), hash = line.find('#');
+    if (k == std::string::npos || (hash != std::string::npos && hash < k)) continue;
+    std::string v = line.substr(k + key.size());
+    while (!v.empty() && (v.back() == '\r' || v.back() == ' ' || v.back() == '\t')) v.pop_back();
+    if (v.size() >= 2 && v.front() == '"' && v.back() == '"') v = v.substr(1, v.size() - 2);
+    if (v.rfind("$HOME/", 0) == 0) v = homeDir() + v.substr(5);
+    if (!v.empty()) return v;
+  }
+  return homeDir() + "/Pictures";
+}
+
+// Snapshots go to "Camera Effects" under the pictures directory, unless that
+// directory exists and cannot be written — a read-only network mount, say — in
+// which case XDG data keeps the shutter working instead of failing every time.
+// A pictures directory that does not exist yet is still preferred: it gets
+// created on the first snapshot.
+std::string snapshotDir() {
+  const std::string pics = xdgPictures();
+  struct stat st{};
+  if (stat(pics.c_str(), &st) != 0 || access(pics.c_str(), W_OK | X_OK) == 0) return pics + "/Camera Effects";
+  return xdgData() + "/camera-effects/snapshots";
+}
 double nowSec() { return std::chrono::duration<double>(clk::now().time_since_epoch()).count(); }
 bool fileExists(const std::string& p) { struct stat st{}; return stat(p.c_str(), &st) == 0; }
 
@@ -828,7 +861,7 @@ void Daemon::removePreview() {
 std::string Daemon::saveSnapshotPng(const std::string& dir, const cv::Mat& bgr, std::string* err) {
   std::vector<uchar> png;
   if (bgr.empty() || !cv::imencode(".png", bgr, png, { cv::IMWRITE_PNG_COMPRESSION, 3 })) { *err = "PNG encode failed"; return ""; }
-  std::string parent = dir.substr(0, dir.rfind('/'));   // ~/Pictures may not exist yet either
+  std::string parent = dir.substr(0, dir.rfind('/'));   // the pictures directory may not exist yet either
   for (const std::string& d : { parent, dir }) {
     if (mkdir(d.c_str(), 0755) == 0) (void)!chown(d.c_str(), (uid_t)-1, getgid());
     else if (errno != EEXIST) { *err = "mkdir " + d + ": " + strerror(errno); return ""; }
@@ -924,7 +957,7 @@ int Daemon::run() {
   std::string sockPath = runtimeDir_ + "/ctl.sock";
   previewPath_ = runtimeDir_ + "/preview.jpg";
   previewTmp_ = previewPath_ + ".tmp";
-  snapDir_ = homeDir() + "/Pictures/Camera Effects";
+  snapDir_ = snapshotDir();
   // Single instance per session (the shell restarts us; a stray manual copy
   // must not fight over the loopback writer).
   int lockFd = open((runtimeDir_ + "/lock").c_str(), O_RDWR | O_CREAT | O_NOFOLLOW | O_CLOEXEC, 0600);

--- a/plugin/Panel.qml
+++ b/plugin/Panel.qml
@@ -734,7 +734,7 @@ Panel {
               cursorShape: Qt.PointingHandCursor
               onClicked: root.snap()
             }
-            PanelToolTip { visible: snapArea.containsMouse; text: "Snapshot · saved to ~/Pictures/Camera Effects and copied"; fontFamily: root.fontFamily }
+            PanelToolTip { visible: snapArea.containsMouse; text: "Snapshot · saved and copied to the clipboard"; fontFamily: root.fontFamily }
           }
           Rectangle {  // countdown: a big centred number on a dim backdrop
             anchors.centerIn: parent

--- a/plugin/Service.qml
+++ b/plugin/Service.qml
@@ -85,7 +85,7 @@ Item {
   // Every effect of the current camera back to the built-in defaults (the
   // global block / placeholder / preview-mirror settings are not touched).
   function reset() { return send({ cmd: "reset" }) }
-  // The daemon saves its next output frame as a PNG under ~/Pictures/Camera Effects
+  // The daemon saves its next output frame as a PNG under the pictures directory
   // and reports it in the state (lastSnapshot): see noteSnapshot for what happens then.
   function snapshot() { return send({ cmd: "snapshot" }) }
   function refresh() { return send({ cmd: "get" }) }


### PR DESCRIPTION
`snapDir_` was `homeDir() + "/Pictures/Camera Effects"`, which has two consequences:

1. `XDG_PICTURES_DIR` is ignored, so a user whose pictures directory is not `~/Pictures` gets snapshots somewhere else than they configured.
2. If that directory cannot be written, every snapshot fails and there is no fallback.

My `~/Pictures` is a read-only CIFS mount of a NAS photo library, so the shutter never worked:

```
$ findmnt -T ~/Pictures -o SOURCE,FSTYPE,OPTIONS
SOURCE                                       FSTYPE OPTIONS
//nas.example/pictures/library/admin         cifs   ro,relatime,...

$ camera-effects-server snap
mkdir /home/pete/Pictures/Camera Effects: Read-only file system
```

Everything else in the plugin worked fine — this is only the snapshot path.

This adds an `xdgPictures()` helper alongside the existing `xdgConfig()`/`xdgData()`/`xdgRuntime()` ones. `XDG_PICTURES_DIR` is a user-dirs setting rather than an exported variable, so it checks the environment first and then reads `user-dirs.dirs`, expanding a leading `$HOME`, before falling back to `~/Pictures` as before. `snapshotDir()` then prefers `<pictures>/Camera Effects` and only diverts to `$XDG_DATA_HOME/camera-effects/snapshots` when the pictures directory **exists and is not writable** — a directory that does not exist yet is still preferred, so the normal first-snapshot-creates-it behaviour is unchanged.

Verified on Omarchy 4 / Arch, kernel 7.0.9-arch2-1:

- Read-only `~/Pictures` (my case): snapshot now lands in `~/.local/share/camera-effects/snapshots/2026-08-19_15-51-31.png`, 878 KB, and `lastSnapshot.path` in the state reports that real path, so the panel's clipboard copy and notification follow it.
- `XDG_PICTURES_DIR` pointed at a writable directory: snapshot lands in `<that dir>/Camera Effects/`.
- Unset `XDG_PICTURES_DIR` with `XDG_PICTURES_DIR="$HOME/Pictures"` in `user-dirs.dirs`: parsed and expanded correctly.
- Builds clean against opencv5 with `-Wall -Wextra`, no new warnings.

I also updated the three comments and the README line that named the old hardcoded path, and made the snapshot tooltip in `Panel.qml` say "saved and copied to the clipboard" rather than naming a path that is now resolved at runtime. Happy to drop the tooltip and README bits if you would rather keep this to the daemon.

One thing I deliberately did not do: the directory is resolved once at startup rather than per snapshot. Re-resolving on each snapshot would cope with a mount that appears or goes read-only while the daemon runs — say the word if you would prefer that and I will move it into `takeSnapshot`.
